### PR TITLE
Add basic Flask task manager prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# task_manager
+# Task Manager
+
+Dieses Beispiel implementiert eine einfache Aufgabenverwaltung mit Flask und SQLite.
+
+Zum Starten:
+```
+python3 app.py
+```
+
+Es wird automatisch eine Datenbank `app.db` erstellt, falls sie noch nicht existiert.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,176 @@
+import os
+from datetime import datetime
+from flask import Flask, render_template, request, redirect, url_for
+from flask_sqlalchemy import SQLAlchemy
+
+DB_FILE = 'app.db'
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{DB_FILE}'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+db = SQLAlchemy(app)
+
+# Models
+class Worker(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False, unique=True)
+
+class Priority(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(50), nullable=False, unique=True)
+    color = db.Column(db.String(20), default='primary')
+
+class Status(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(50), nullable=False, unique=True)
+    color = db.Column(db.String(20), default='secondary')
+
+class Task(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    project = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.String(400))
+    responsible_id = db.Column(db.Integer, db.ForeignKey('worker.id'))
+    priority_id = db.Column(db.Integer, db.ForeignKey('priority.id'))
+    status_id = db.Column(db.Integer, db.ForeignKey('status.id'))
+    due_date = db.Column(db.Date)
+
+    responsible = db.relationship('Worker')
+    priority = db.relationship('Priority')
+    status = db.relationship('Status')
+
+class Planning(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    task_id = db.Column(db.Integer, db.ForeignKey('task.id'))
+    worker_id = db.Column(db.Integer, db.ForeignKey('worker.id'))
+    year = db.Column(db.Integer, nullable=False)
+    week = db.Column(db.Integer, nullable=False)
+    hours = db.Column(db.Float, nullable=False)
+
+    task = db.relationship('Task')
+    worker = db.relationship('Worker')
+
+# Initialize DB with some defaults
+@app.before_first_request
+def init_db():
+    if not os.path.exists(DB_FILE):
+        db.create_all()
+        db.session.add(Worker(name='Max Mustermann'))
+        db.session.add(Priority(name='Normal', color='primary'))
+        db.session.add(Status(name='Offen', color='secondary'))
+        db.session.commit()
+
+# Routes
+@app.route('/')
+def dashboard():
+    week = request.args.get('week')
+    worker_id = request.args.get('worker')
+    tasks = Task.query
+    if worker_id:
+        tasks = tasks.filter_by(responsible_id=worker_id)
+    tasks = tasks.all()
+    workers = Worker.query.all()
+    return render_template('dashboard.html', tasks=tasks, workers=workers)
+
+@app.route('/tasks')
+def tasks():
+    tasks = Task.query.all()
+    return render_template('tasks.html', tasks=tasks)
+
+@app.route('/tasks/new', methods=['GET', 'POST'])
+def task_new():
+    if request.method == 'POST':
+        task = Task(
+            project=request.form['project'],
+            description=request.form['description'],
+            responsible_id=request.form['responsible'],
+            priority_id=request.form['priority'],
+            status_id=request.form['status'],
+            due_date=request.form['due_date'] or None
+        )
+        if task.due_date:
+            task.due_date = datetime.strptime(task.due_date, '%Y-%m-%d').date()
+        db.session.add(task)
+        db.session.commit()
+        return redirect(url_for('tasks'))
+    workers = Worker.query.all()
+    priorities = Priority.query.all()
+    statuses = Status.query.all()
+    return render_template('task_form.html', workers=workers, priorities=priorities, statuses=statuses)
+
+@app.route('/tasks/edit/<int:task_id>', methods=['GET', 'POST'])
+def task_edit(task_id):
+    task = Task.query.get_or_404(task_id)
+    if request.method == 'POST':
+        task.project = request.form['project']
+        task.description = request.form['description']
+        task.responsible_id = request.form['responsible']
+        task.priority_id = request.form['priority']
+        task.status_id = request.form['status']
+        due = request.form['due_date'] or None
+        if due:
+            task.due_date = datetime.strptime(due, '%Y-%m-%d').date()
+        else:
+            task.due_date = None
+        db.session.commit()
+        return redirect(url_for('tasks'))
+    workers = Worker.query.all()
+    priorities = Priority.query.all()
+    statuses = Status.query.all()
+    return render_template('task_form.html', task=task, workers=workers, priorities=priorities, statuses=statuses)
+
+@app.route('/tasks/delete/<int:task_id>', methods=['POST'])
+def task_delete(task_id):
+    task = Task.query.get_or_404(task_id)
+    db.session.delete(task)
+    db.session.commit()
+    return redirect(url_for('tasks'))
+
+@app.route('/planning')
+def planning():
+    items = Planning.query.all()
+    return render_template('planning.html', items=items)
+
+@app.route('/planning/new', methods=['GET', 'POST'])
+def planning_new():
+    if request.method == 'POST':
+        plan = Planning(
+            task_id=request.form['task'],
+            worker_id=request.form['worker'],
+            year=request.form['year'],
+            week=request.form['week'],
+            hours=request.form['hours'],
+        )
+        db.session.add(plan)
+        db.session.commit()
+        return redirect(url_for('planning'))
+    tasks = Task.query.all()
+    workers = Worker.query.all()
+    return render_template('planning_form.html', tasks=tasks, workers=workers)
+
+@app.route('/planning/delete/<int:item_id>', methods=['POST'])
+def planning_delete(item_id):
+    item = Planning.query.get_or_404(item_id)
+    db.session.delete(item)
+    db.session.commit()
+    return redirect(url_for('planning'))
+
+@app.route('/masterdata', methods=['GET', 'POST'])
+def masterdata():
+    if request.method == 'POST':
+        table = request.form['table']
+        name = request.form['name']
+        color = request.form.get('color')
+        if table == 'worker':
+            db.session.add(Worker(name=name))
+        elif table == 'priority':
+            db.session.add(Priority(name=name, color=color or 'primary'))
+        elif table == 'status':
+            db.session.add(Status(name=name, color=color or 'secondary'))
+        db.session.commit()
+        return redirect(url_for('masterdata'))
+    workers = Worker.query.all()
+    priorities = Priority.query.all()
+    statuses = Status.query.all()
+    return render_template('masterdata.html', workers=workers, priorities=priorities, statuses=statuses)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+flask_sqlalchemy

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,1 @@
+body { font-size: 0.9rem; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <title>Task Manager</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body class="d-flex flex-column min-vh-100">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('dashboard') }}"><i class="bi bi-speedometer2"></i> Dashboard</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample" aria-controls="navbarsExample" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse" id="navbarsExample">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('tasks') }}"><i class="bi bi-card-checklist"></i> Aufgaben</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('planning') }}"><i class="bi bi-calendar-week"></i> Wochenplanung</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('masterdata') }}"><i class="bi bi-gear"></i> Stammdaten</a></li>
+      </ul>
+      <button class="btn btn-outline-light" id="toggleMode"><i class="bi bi-moon"></i></button>
+    </div>
+  </div>
+</nav>
+<div class="container my-4 flex-fill">
+  {% block content %}{% endblock %}
+</div>
+<footer class="bg-dark text-center text-white py-3 mt-auto">
+  Task Manager Example
+</footer>
+<script>
+  document.getElementById('toggleMode').addEventListener('click', function() {
+    const html = document.documentElement;
+    if (html.getAttribute('data-bs-theme') === 'dark') {
+      html.setAttribute('data-bs-theme', 'light');
+    } else {
+      html.setAttribute('data-bs-theme', 'dark');
+    }
+  });
+</script>
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Dashboard</h1>
+<table class="table table-sm">
+  <thead>
+    <tr>
+      <th>Projekt</th>
+      <th>Beschreibung</th>
+      <th>Bearbeiter</th>
+      <th>Prio</th>
+      <th>Status</th>
+      <th>Fälligkeit</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for t in tasks %}
+    <tr class="table-{{ t.priority.color }}">
+      <td>{{ t.project }}</td>
+      <td>{{ t.description }}</td>
+      <td>{{ t.responsible.name if t.responsible else '' }}</td>
+      <td>{{ t.priority.name if t.priority else '' }}</td>
+      <td>{{ t.status.name if t.status else '' }}</td>
+      <td>{{ t.due_date or '' }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/masterdata.html
+++ b/templates/masterdata.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Stammdaten</h1>
+<form method="post" class="row g-3">
+  <div class="col-md-3">
+    <select class="form-select" name="table">
+      <option value="worker">Bearbeiter</option>
+      <option value="priority">Prio</option>
+      <option value="status">Status</option>
+    </select>
+  </div>
+  <div class="col-md-3">
+    <input type="text" class="form-control" name="name" placeholder="Name" required>
+  </div>
+  <div class="col-md-3">
+    <input type="text" class="form-control" name="color" placeholder="Farbe (Bootstrap)">
+  </div>
+  <div class="col-md-3">
+    <button class="btn btn-primary"><i class="bi bi-plus"></i> Hinzufügen</button>
+  </div>
+</form>
+<div class="row mt-4">
+  <div class="col-md-4">
+    <h3>Bearbeiter</h3>
+    <ul>
+    {% for w in workers %}<li>{{ w.name }}</li>{% endfor %}
+    </ul>
+  </div>
+  <div class="col-md-4">
+    <h3>Prio</h3>
+    <ul>
+    {% for p in priorities %}<li>{{ p.name }} ({{ p.color }})</li>{% endfor %}
+    </ul>
+  </div>
+  <div class="col-md-4">
+    <h3>Status</h3>
+    <ul>
+    {% for s in statuses %}<li>{{ s.name }} ({{ s.color }})</li>{% endfor %}
+    </ul>
+  </div>
+</div>
+{% endblock %}

--- a/templates/planning.html
+++ b/templates/planning.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Wochenplanung</h1>
+<a href="{{ url_for('planning_new') }}" class="btn btn-primary mb-3"><i class="bi bi-plus"></i> Neu</a>
+<table class="table table-sm">
+  <thead>
+    <tr>
+      <th>Aufgabe</th>
+      <th>Bearbeiter</th>
+      <th>Jahr</th>
+      <th>KW</th>
+      <th>Stunden</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for p in items %}
+    <tr>
+      <td>{{ p.task.project if p.task else '' }}</td>
+      <td>{{ p.worker.name if p.worker else '' }}</td>
+      <td>{{ p.year }}</td>
+      <td>{{ p.week }}</td>
+      <td>{{ p.hours }}</td>
+      <td>
+        <form action="{{ url_for('planning_delete', item_id=p.id) }}" method="post" style="display:inline" onsubmit="return confirm('Löschen?');">
+          <button class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/planning_form.html
+++ b/templates/planning_form.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Planung</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Aufgabe</label>
+    <select class="form-select" name="task">
+      {% for t in tasks %}
+      <option value="{{ t.id }}">{{ t.project }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Bearbeiter</label>
+    <select class="form-select" name="worker">
+      {% for w in workers %}
+      <option value="{{ w.id }}">{{ w.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Jahr</label>
+    <input type="number" class="form-control" name="year" value="{{ current_year }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">KW</label>
+    <input type="number" class="form-control" name="week" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Stunden</label>
+    <input type="number" step="0.1" class="form-control" name="hours" required>
+  </div>
+  <button class="btn btn-primary"><i class="bi bi-save"></i> Speichern</button>
+</form>
+{% endblock %}

--- a/templates/task_form.html
+++ b/templates/task_form.html
@@ -1,0 +1,43 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Aufgabe</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Projekt</label>
+    <input type="text" class="form-control" name="project" value="{{ task.project if task else '' }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Beschreibung</label>
+    <textarea class="form-control" name="description">{{ task.description if task else '' }}</textarea>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Verantwortlicher</label>
+    <select class="form-select" name="responsible">
+      {% for w in workers %}
+      <option value="{{ w.id }}" {% if task and task.responsible_id==w.id %}selected{% endif %}>{{ w.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Prio</label>
+    <select class="form-select" name="priority">
+      {% for p in priorities %}
+      <option value="{{ p.id }}" {% if task and task.priority_id==p.id %}selected{% endif %}>{{ p.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Status</label>
+    <select class="form-select" name="status">
+      {% for s in statuses %}
+      <option value="{{ s.id }}" {% if task and task.status_id==s.id %}selected{% endif %}>{{ s.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Fälligkeit</label>
+    <input type="date" class="form-control" name="due_date" value="{{ task.due_date if task and task.due_date else '' }}">
+  </div>
+  <button class="btn btn-primary"><i class="bi bi-save"></i> Speichern</button>
+</form>
+{% endblock %}

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Aufgaben</h1>
+<a href="{{ url_for('task_new') }}" class="btn btn-primary mb-3"><i class="bi bi-plus"></i> Neu</a>
+<table class="table table-sm">
+  <thead>
+    <tr>
+      <th>Projekt</th>
+      <th>Beschreibung</th>
+      <th>Bearbeiter</th>
+      <th>Prio</th>
+      <th>Status</th>
+      <th>Fälligkeit</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for t in tasks %}
+    <tr class="table-{{ t.priority.color }}">
+      <td>{{ t.project }}</td>
+      <td>{{ t.description }}</td>
+      <td>{{ t.responsible.name if t.responsible else '' }}</td>
+      <td>{{ t.priority.name if t.priority else '' }}</td>
+      <td>{{ t.status.name if t.status else '' }}</td>
+      <td>{{ t.due_date or '' }}</td>
+      <td>
+        <a href="{{ url_for('task_edit', task_id=t.id) }}" class="btn btn-sm btn-secondary"><i class="bi bi-pencil"></i></a>
+        <form action="{{ url_for('task_delete', task_id=t.id) }}" method="post" style="display:inline" onsubmit="return confirm('Löschen?');">
+          <button class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- build a Flask prototype using SQLite
- include dark mode, navigation with icons and Bootstrap styles
- keep sample HTML templates for dashboard, tasks, planning and masterdata
- document how to run the server

## Testing
- `pytest -q`
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_688a13ea706c8321974f480be7dd7367