### PR TITLE
Add year master data and dynamic week selection

### DIFF
--- a/templates/masterdata.html
+++ b/templates/masterdata.html
@@ -7,6 +7,7 @@
       <option value="worker">Bearbeiter</option>
       <option value="priority">Prio</option>
       <option value="status">Status</option>
+      <option value="year">Jahr</option>
     </select>
   </div>
   <div class="col-md-3">
@@ -20,7 +21,7 @@
   </div>
 </form>
 <div class="row mt-4">
-  <div class="col-md-4">
+  <div class="col-md-3">
     <h3>Bearbeiter</h3>
     <ul class="list-group">
     {% for w in workers %}
@@ -36,7 +37,7 @@
     {% endfor %}
     </ul>
   </div>
-  <div class="col-md-4">
+  <div class="col-md-3">
     <h3>Prio</h3>
     <ul class="list-group">
     {% for p in priorities %}
@@ -52,7 +53,7 @@
     {% endfor %}
     </ul>
   </div>
-  <div class="col-md-4">
+  <div class="col-md-3">
     <h3>Status</h3>
     <ul class="list-group">
     {% for s in statuses %}
@@ -61,6 +62,22 @@
         <span>
           <a href="{{ url_for('masterdata_edit', table='status', item_id=s.id) }}" class="btn btn-sm btn-secondary"><i class="bi bi-pencil"></i></a>
           <form action="{{ url_for('masterdata_delete', table='status', item_id=s.id) }}" method="post" style="display:inline" onsubmit="return confirm('Löschen?');">
+            <button class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
+          </form>
+        </span>
+      </li>
+    {% endfor %}
+    </ul>
+  </div>
+  <div class="col-md-3">
+    <h3>Jahre</h3>
+    <ul class="list-group">
+    {% for y in years %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        {{ y.year }}
+        <span>
+          <a href="{{ url_for('masterdata_edit', table='year', item_id=y.id) }}" class="btn btn-sm btn-secondary"><i class="bi bi-pencil"></i></a>
+          <form action="{{ url_for('masterdata_delete', table='year', item_id=y.id) }}" method="post" style="display:inline" onsubmit="return confirm('Löschen?');">
             <button class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
           </form>
         </span>

--- a/templates/masterdata_form.html
+++ b/templates/masterdata_form.html
@@ -3,10 +3,10 @@
 <h1>Stammdaten bearbeiten</h1>
 <form method="post">
   <div class="mb-3">
-    <label class="form-label">Name</label>
-    <input type="text" class="form-control" name="name" value="{{ item.name }}" required>
+    <label class="form-label">{% if table == 'year' %}Jahr{% else %}Name{% endif %}</label>
+    <input type="text" class="form-control" name="name" value="{{ item.name if table != 'year' else item.year }}" required>
   </div>
-  {% if table != 'worker' %}
+  {% if table != 'worker' and table != 'year' %}
   <div class="mb-3">
     <label class="form-label">Farbe</label>
     <input type="text" class="form-control" name="color" value="{{ item.color }}">

--- a/templates/planning_form.html
+++ b/templates/planning_form.html
@@ -20,11 +20,15 @@
   </div>
   <div class="mb-3">
     <label class="form-label">Jahr</label>
-    <input type="number" class="form-control" name="year" value="{{ current_year }}" required>
+    <select class="form-select" name="year" id="yearSelect">
+      {% for y in years %}
+      <option value="{{ y.year }}">{{ y.year }}</option>
+      {% endfor %}
+    </select>
   </div>
   <div class="mb-3">
     <label class="form-label">KW</label>
-    <input type="number" class="form-control" name="week" required>
+    <select class="form-select" name="week" id="weekSelect"></select>
   </div>
   <div class="mb-3">
     <label class="form-label">Stunden</label>
@@ -32,4 +36,21 @@
   </div>
   <button class="btn btn-primary"><i class="bi bi-save"></i> Speichern</button>
 </form>
+<script>
+async function loadWeeks() {
+  const year = document.getElementById('yearSelect').value;
+  const resp = await fetch('{{ url_for('weeks', year=0) }}'.replace('0', year));
+  const data = await resp.json();
+  const select = document.getElementById('weekSelect');
+  select.innerHTML = '';
+  data.forEach(w => {
+    const opt = document.createElement('option');
+    opt.value = w.week;
+    opt.textContent = w.label;
+    select.appendChild(opt);
+  });
+}
+document.getElementById('yearSelect').addEventListener('change', loadWeeks);
+document.addEventListener('DOMContentLoaded', loadWeeks);
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `PlanYear` model with DB initialization
- allow managing years in master data
- replace year input in planning form with dropdown
- dynamically fetch weeks for the selected year
- tidy master data markup

## Testing
- `python -m py_compile app.py`
- `flake8 app.py templates/*.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688a1d93b32083218ff437d7f9583956